### PR TITLE
spring-boot-prometheus to 0.0.13

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.89
 - name: spring-boot-prometheus
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.10
+  version: 0.0.13


### PR DESCRIPTION
Promote spring-boot-prometheus to version 0.0.13